### PR TITLE
fix Tiled-MMConfig.cmake

### DIFF
--- a/cmake/Tiled-MMConfig.cmake.in
+++ b/cmake/Tiled-MMConfig.cmake.in
@@ -5,8 +5,7 @@ if(NOT TARGET Tiled-MM::Tiled-MM)
     set(TILEDMM_GPU_BACKEND "@TILEDMM_GPU_BACKEND@")
 
     if(TILEDMM_GPU_BACKEND STREQUAL "CUDA")
-        find_package(CUDA REQUIRED)
-        find_package(CUBLAS REQUIRED)
+        find_package(CUDAToolkit REQUIRED)
     endif()
 
     if(TILEDMM_GPU_BACKEND STREQUAL "ROCM")


### PR DESCRIPTION
- use find_package(CUDAToolkit) instead of find_package(CUDA)
- remove find_package(CUBLAS), there is no FindCUBLAS.cmake (neither in official cmake nor in tiled-mm)

ping @mtaillefumier 